### PR TITLE
Use conversations_list api instead of channels_list

### DIFF
--- a/lib/ruboty/handlers/yasumimasu.rb
+++ b/lib/ruboty/handlers/yasumimasu.rb
@@ -54,7 +54,7 @@ module Ruboty
       end
 
       def api_channels_list
-        "https://slack.com/api/channels.list?token=#{ENV['RUBOTY_YASUMIMASU_SLACK_TOKEN']}"
+        "https://slack.com/api/conversations.list?token=#{ENV['RUBOTY_YASUMIMASU_SLACK_TOKEN']}"
       end
     end
   end


### PR DESCRIPTION
## :sparkles: 目的

Channels.list API はすでに廃止されている。
https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api#prepare

## :muscle: 方針

> Lists all channels in a Slack team.
> Replaced by: conversations.list users.conversations 
> https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api#prepare

## :wrench: 実装

irb で同様の動きになることを確認 ※ 以下 ruby3.0.0 なので Kernal#open が使えない

```
irb> channels = JSON.parse(URI.parse("https://slack.com/api/conversations.list?token=<token>").read)['channels']
=> [{"id"=>"xxxxx", "name"=>"general", "is_channel"=>true, "is_group"=>false, "is_im"=>false, "created"=>1407307559, ...
irb> channels.find { |channel|  channel['id'] == 'xxxxx' }['name']
=> "general"
```
